### PR TITLE
deploy_key > branch - Typo In Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Use these inputs to customise the action.
 Input Name | Default | Required? | Description
 ------------ | ------------- | ------------ | -------------
 deploy_key | N/A | Y | The Hatchbox project deploy key
-deploy_key | master | N | The branch that needs to be deployed
+branch | master | N | The branch that needs to be deployed
 
 #### Example
 


### PR DESCRIPTION
I spotted the `deploy_key` input was repeated in the readme 👍 I think you meant it to be "branch".