### PR TITLE
Fix: Send POST request to kick-off deployment

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,5 +8,5 @@ else
   url="https://app.hatchbox.io/webhooks/deployments/$INPUT_DEPLOY_KEY?latest=true"
 fi
 
-curl --fail $url
+curl -X POST --fail $url
 echo "Success"


### PR DESCRIPTION
I've never used Hatchbox classic, so I don't know if this would work there.

Also, when `curl` failed, my deploy GitHub Action didn't fail as it should.

```
> curl --fail https://app.hatchbox.io/webhooks/deployments/XYZ\?latest\=true
curl: (22) The requested URL returned error: 404
```

<details><summary>Here's the screenshot of "successful" build</summary>


![Screenshot 2023-09-05 at 16 26 46](https://github.com/hatchboxio/github-hatchbox-deploy-action/assets/67437/4b95211f-a840-4ae2-8a13-2042493885f5)</details>
