### PR TITLE
Use GitHub SHA to deploy on Hatchbox v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Drop Hatchbox Classic support
 * Deploy using ${{ github.sha }} instead of latest branch commit
+* Include response in GitHub Action outputs
 * Raise error on failure
 
 ### v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+### v2
+
+* Drop Hatchbox Classic support
+* Deploy using ${{ github.sha }} instead of latest branch commit
+* Raise error on failure
+
+### v1
+
+* Trigger deployments in Hatchbox.io and Hatchbox Classic

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Hatchbox Notify Deploy Action
+# Hatchbox.io Deploy Action
 
-Sending deployment notifications to Hatchbox.
+Trigger Hatchbox.io app deployments.
+
+For Hatchbox Classic users, see [v1]().
 
 #### Inputs
 
@@ -10,8 +12,6 @@ Input Name | Default | Required? | Description
 ------------ | ------------- | ------------ | -------------
 deploy_key | N/A | Y | Your Hatchbox.io app's Deploy Key.
 sha | ${{ github.sha }} | N | The commit sha to deploy. Default's to the sha that triggered the GitHub Action.
-classic | false | N | Deploy to Hatchbox Classic
-branch | main | N | (Hatchbox Classic Only) The branch to be deployed
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,21 +8,35 @@ Use these inputs to customise the action.
 
 Input Name | Default | Required? | Description
 ------------ | ------------- | ------------ | -------------
-deploy_key | N/A | Y | The Hatchbox project deploy key 
-classic | false | N | If Hatchbox Classic is used or not
-branch | master | N | (Hatchbox Classic Only) The branch to be deployed
+deploy_key | N/A | Y | Your Hatchbox.io app's Deploy Key.
+sha | ${{ github.sha }} | N | The commit sha to deploy. Default's to the sha that triggered the GitHub Action.
+classic | false | N | Deploy to Hatchbox Classic
+branch | main | N | (Hatchbox Classic Only) The branch to be deployed
 
+## Usage
 
-#### Deploy Key
-Set HATCHBOX_DEPLOY_KEY to XYZ in your GitHub Secrets.
+Set `HATCHBOX_DEPLOY_KEY` in your GitHub Secrets. You can find the Deploy Key in the URL on the App's Repository tab in Hatchbox.io.
 
-**Hatchbox v2**
+#### Example
 
-You can find the "deploy key" in the URL on the App's Repository tab in Hatchbox v2. For example, it would show:
+```yaml
+# .github/workflows/deploy.yml
+on:
+  push:
+    branches:
+      - main
 
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: hatchboxio/github-hatchbox-deploy-action@v1
+      with:
+        deploy_key: ${{ secrets.HATCHBOX_DEPLOY_KEY }}
 ```
-https://app.hatchbox.io/webhooks/deployments/XYZ?latest=true
-```
+
+## Hatchbox Classic
 
 **Hatchbox Classic**
 
@@ -34,10 +48,12 @@ https://www.hatchbox.io/webhooks/github/push/XYZ
 #### Example
 
 ```yaml
+# .github/workflows/deploy.yml
+
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:
@@ -47,5 +63,6 @@ jobs:
     - uses: hatchboxio/github-hatchbox-deploy-action@v1
       with:
         deploy_key: ${{ secrets.HATCHBOX_DEPLOY_KEY }}
-        branch: main
+        classic: "true"
+        branch: "main"
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Hatchbox Deploy Action'
-description: 'Send deployment notifications to the Hatchbox API'
+name: 'Hatchbox.io Deploy Action'
+description: 'Send deployment notifications to the Hatchbox.io API'
 branding:
   icon: 'globe'
   color: 'red'
@@ -11,6 +11,9 @@ inputs:
     description: 'The commit sha to be deployed.'
     required: false
     default: ${{ github.sha }}
+outputs:
+  response:
+    description: "JSON response for the Hatchbox.io deployment"
 
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -5,12 +5,16 @@ branding:
   color: 'red'
 inputs:
   deploy_key:
-    description: 'The Hatchbox project deploy key'
+    description: 'Your Hatchbox.io app's Deploy Key.'
     required: true
+  sha:
+    description: 'The commit sha to be deployed.'
+    required: false
+    default: ${{ github.sha }}
   branch:
     description: 'The branch that needs to be deployed'
     required: false
-    default: 'master'
+    default: 'main'
   classic:
     description: 'If hatchbox classic is used'
     required: false
@@ -21,5 +25,6 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.deploy_key }}
+    - ${{ inputs.sha }}
     - ${{ inputs.branch }}
     - ${{ inputs.classic }}

--- a/action.yml
+++ b/action.yml
@@ -11,14 +11,6 @@ inputs:
     description: 'The commit sha to be deployed.'
     required: false
     default: ${{ github.sha }}
-  branch:
-    description: 'The branch that needs to be deployed'
-    required: false
-    default: 'main'
-  classic:
-    description: 'If hatchbox classic is used'
-    required: false
-    default: 'false'
 
 runs:
   using: 'docker'
@@ -26,5 +18,3 @@ runs:
   args:
     - ${{ inputs.deploy_key }}
     - ${{ inputs.sha }}
-    - ${{ inputs.branch }}
-    - ${{ inputs.classic }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,5 +2,6 @@
 
 set -xe
 
-curl -X POST --fail-with-body "https://app.hatchbox.io/webhooks/deployments/$INPUT_DEPLOY_KEY?sha=$INPUT_SHA"
+response=curl -X POST --fail-with-body "https://app.hatchbox.io/webhooks/deployments/$INPUT_DEPLOY_KEY?sha=$INPUT_SHA"
+echo "response=$response" >> $GITHUB_OUTPUT
 echo "Deployment has started on Hatchbox.io"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/sh -l
 
-set -x 
+# print commands and exit on failure
+set -xe
 
 if [[ $INPUT_CLASSIC == "true" ]]; then
   url="https://classic.hatchbox.io/webhooks/custom/push/$INPUT_DEPLOY_KEY?ref=refs%2Fheads%2F$INPUT_BRANCH"
 else
-  url="https://app.hatchbox.io/webhooks/deployments/$INPUT_DEPLOY_KEY?latest=true"
+  url="https://app.hatchbox.io/webhooks/deployments/$INPUT_DEPLOY_KEY?sha=$INPUT_SHA"
 fi
 
 curl -X POST --fail $url

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,13 +1,6 @@
 #!/bin/sh -l
 
-# print commands and exit on failure
 set -xe
 
-if [[ $INPUT_CLASSIC == "true" ]]; then
-  url="https://classic.hatchbox.io/webhooks/custom/push/$INPUT_DEPLOY_KEY?ref=refs%2Fheads%2F$INPUT_BRANCH"
-else
-  url="https://app.hatchbox.io/webhooks/deployments/$INPUT_DEPLOY_KEY?sha=$INPUT_SHA"
-fi
-
-curl -X POST --fail $url
-echo "Success"
+curl -X POST --fail-with-body "https://app.hatchbox.io/webhooks/deployments/$INPUT_DEPLOY_KEY?sha=$INPUT_SHA"
+echo "Deployment has started on Hatchbox.io"


### PR DESCRIPTION
This refactors the deploy script for a few major things:

- Deploy ${{ github.sha }}. This is the sha that triggered the action. This will ensure that the correct commit is deployed in case two pushes are run in close succession.
- Raise error on failure using `set -e`
- Remove Hatchbox Classic support in v2.